### PR TITLE
Removal of custom typedef any since it is misleading with std::any

### DIFF
--- a/inc/TRestLegacyProcess.h
+++ b/inc/TRestLegacyProcess.h
@@ -28,8 +28,8 @@
 //! Base class for legacy process
 class TRestLegacyProcess : public TRestEventProcess {
    public:
-    any GetInputEvent() const final { return any((TRestEvent*)nullptr); }
-    any GetOutputEvent() const final { return any((TRestEvent*)nullptr); }
+    RESTValue GetInputEvent() const final { return RESTValue((TRestEvent*)nullptr); }
+    RESTValue GetOutputEvent() const final { return RESTValue((TRestEvent*)nullptr); }
 
     void InitProcess() final{};
     TRestEvent* ProcessEvent(TRestEvent* eventInput) final {


### PR DESCRIPTION
Removal of custom `typedef REST_Reflection::TRestReflector any` since it is misleading with `std::any`.

The custom typedef `any` has been replaced by existing `typedef REST_Reflection::TRestReflector RESTValue`

Related PR https://github.com/rest-for-physics/framework/pull/471